### PR TITLE
Feature/ppo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,18 +28,18 @@ jobs:
           pip install -e .
 
       - name: Run tests
-        run: pytest --doctest-modules --cov=pixyzrl --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov-report=xml pixyzrl | tee pytest-coverage.txt
+        run: pytest --doctest-modules --cov=pixyzrl --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov-report=xml pixyzrl | tee pytest-coverage.xml
 
       - name: Pytest coverage comment
         uses: MishaKav/pytest-coverage-comment@main
         with:
-          pytest-coverage-path: ./pytest-coverage.txt
+          pytest-coverage-path: ./pytest-coverage.xml
           junitxml-path: ./pytest.xml
 
       - name: Upload coverage reports to Codecov with GitHub Action
         uses: codecov/codecov-action@v3
         with:
           token: 3095d231-c0f1-4412-b2f7-d2c9e620288e
-          file: ./pytest-coverage.txt
+          file: ./pytest-coverage.xml
           flags: unittests
           name: codecov-umbrella

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,18 +28,18 @@ jobs:
           pip install -e .
 
       - name: Run tests
-        run: pytest --doctest-modules --cov=pixyzrl --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov-report=xml pixyzrl | tee pytest-coverage.xml
+        run: pytest --doctest-modules --cov=pixyzrl --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov-report=xml pixyzrl | tee coverage.xml
 
       - name: Pytest coverage comment
         uses: MishaKav/pytest-coverage-comment@main
         with:
-          pytest-coverage-path: ./pytest-coverage.xml
+          pytest-coverage-path: ./coverage.xml
           junitxml-path: ./pytest.xml
 
       - name: Upload coverage reports to Codecov with GitHub Action
         uses: codecov/codecov-action@v3
         with:
           token: 3095d231-c0f1-4412-b2f7-d2c9e620288e
-          file: ./pytest-coverage.xml
+          file: ./coverage.xml
           flags: unittests
           name: codecov-umbrella


### PR DESCRIPTION
This pull request includes changes to the CI workflow configuration to improve the handling of coverage reports. The most important change involves renaming the coverage report file to ensure consistency across different steps.

Changes to CI workflow configuration:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL31-R43): Changed the output file for coverage reports from `pytest-coverage.txt` to `coverage.xml` to maintain consistency in the workflow steps.