### PR TITLE
Implement Soft Actor-Critic (SAC) off-policy agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 
 [**PixyzRL**](https://github.com/ItoMasaki/PixyzRL) is a reinforcement learning (RL) framework based on **probabilistic generative models** and **Bayesian theory**. Built on top of the [Pixyz](https://github.com/masa-su/pixyz) library, it provides a modular and flexible design to enable uncertainty-aware decision-making and improve sample efficiency. PixyzRL supports:
 - **Probabilistic Policy Optimization** (e.g., PPO, A2C)
+- **Soft Actor-Critic (SAC)** for continuous-control off-policy learning
 - **On-policy and Off-policy Learning**
 - **Memory Management for RL (Replay Buffer, Rollout Buffer)**
 - **Advantage calculations are supported by MC / GAE / GRPO**
@@ -218,6 +219,7 @@ PixyzRL
 
 ## Future Work
 
+- [x] Implement **Soft Actor-Critic (SAC)**
 - [ ] Implement **Deep Q-Network (DQN)**
 - [ ] Implement **Dreamer** (model-based RL)
 - [ ] Integrate with **ChatGPT for automatic architecture generation**

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 |CartPole-v1 ( GRPO ) TEST||
 |<video src=https://github.com/user-attachments/assets/c4889b64-0936-4f22-8778-466b15e7a4cc/>||
 
-
+SAC example: `examples/pendulum_v1_sac.py`
 
 ## Installation
 

--- a/examples/pendulum_v1_sac.py
+++ b/examples/pendulum_v1_sac.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import argparse
+import random
+
+import gymnasium as gym
+import numpy as np
+import torch
+from pixyz.distributions import Deterministic, Normal
+from torch import nn
+
+from pixyzrl.memory import RolloutBuffer
+from pixyzrl.models import SAC
+
+
+class Actor(Normal):
+    def __init__(self, obs_dim: int, action_dim: int, hidden_dim: int = 256) -> None:
+        super().__init__(var=["a"], cond_var=["o"], name="pi")
+        self.backbone = nn.Sequential(
+            nn.Linear(obs_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.ReLU(),
+        )
+        self.loc_head = nn.Linear(hidden_dim, action_dim)
+        self.log_scale_head = nn.Linear(hidden_dim, action_dim)
+
+    def forward(self, o: torch.Tensor) -> dict[str, torch.Tensor]:
+        h = self.backbone(o)
+        loc = self.loc_head(h)
+        log_scale = torch.clamp(self.log_scale_head(h), -5.0, 2.0)
+        return {"loc": loc, "scale": log_scale.exp()}
+
+
+class Critic(Deterministic):
+    def __init__(self, obs_dim: int, action_dim: int, hidden_dim: int = 256, name: str = "q") -> None:
+        super().__init__(var=["q"], cond_var=["o", "a"], name=name)
+        self.net = nn.Sequential(
+            nn.Linear(obs_dim + action_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, 1),
+        )
+
+    def forward(self, o: torch.Tensor, a: torch.Tensor) -> dict[str, torch.Tensor]:
+        return {"q": self.net(torch.cat([o, a], dim=-1))}
+
+
+def run_training(args: argparse.Namespace) -> None:
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    env = gym.make("Pendulum-v1")
+    obs, _ = env.reset(seed=args.seed)
+
+    obs_dim = int(np.prod(env.observation_space.shape))
+    action_dim = int(np.prod(env.action_space.shape))
+
+    actor = Actor(obs_dim, action_dim)
+    critic1 = Critic(obs_dim, action_dim, name="q1")
+    critic2 = Critic(obs_dim, action_dim, name="q2")
+
+    sac = SAC(
+        actor=actor,
+        critic1=critic1,
+        critic2=critic2,
+        lr_actor=args.lr_actor,
+        lr_critic=args.lr_critic,
+        lr_alpha=args.lr_alpha,
+        gamma=args.gamma,
+        tau=args.tau,
+        alpha=args.alpha,
+        action_var="a",
+        obs_var="o",
+        next_obs_var="o_next",
+        reward_var="r",
+        done_var="d",
+        device=str(device),
+    )
+
+    replay = RolloutBuffer(
+        buffer_size=args.buffer_size,
+        env_dict={
+            "obs": {"shape": (obs_dim,), "map": "o"},
+            "next_obs": {"shape": (obs_dim,), "map": "o_next"},
+            "action": {"shape": (action_dim,), "map": "a"},
+            "reward": {"shape": (1,), "map": "r"},
+            "done": {"shape": (1,), "map": "d"},
+        },
+        n_envs=1,
+    )
+
+    episode_rewards: list[float] = []
+    episode_reward = 0.0
+
+    for step in range(1, args.total_steps + 1):
+        if step < args.warmup_steps:
+            action = env.action_space.sample()
+        else:
+            with torch.no_grad():
+                sample = sac.select_action({"o": torch.tensor(obs, dtype=torch.float32).unsqueeze(0)})
+            action = sample["a"].squeeze(0).cpu().numpy()
+            action = np.clip(action, env.action_space.low, env.action_space.high)
+
+        next_obs, reward, terminated, truncated, _ = env.step(action)
+        done = terminated or truncated
+
+        replay.add(
+            obs=torch.tensor(obs, dtype=torch.float32),
+            next_obs=torch.tensor(next_obs, dtype=torch.float32),
+            action=torch.tensor(action, dtype=torch.float32),
+            reward=torch.tensor([reward], dtype=torch.float32),
+            done=torch.tensor([float(done)], dtype=torch.float32),
+        )
+
+        obs = next_obs
+        episode_reward += reward
+
+        if done:
+            episode_rewards.append(episode_reward)
+            moving = float(np.mean(episode_rewards[-10:]))
+            print(f"step={step:6d} episode_reward={episode_reward:8.2f} moving10={moving:8.2f}")
+            obs, _ = env.reset()
+            episode_reward = 0.0
+
+        if len(replay) >= args.batch_size and step % args.update_interval == 0:
+            sac.train_step(replay, batch_size=args.batch_size, num_epochs=args.update_epochs)
+
+    env.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Pendulum-v1 SAC example")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--total-steps", type=int, default=20000)
+    parser.add_argument("--warmup-steps", type=int, default=1000)
+    parser.add_argument("--buffer-size", type=int, default=100000)
+    parser.add_argument("--batch-size", type=int, default=256)
+    parser.add_argument("--update-interval", type=int, default=1)
+    parser.add_argument("--update-epochs", type=int, default=1)
+    parser.add_argument("--gamma", type=float, default=0.99)
+    parser.add_argument("--tau", type=float, default=0.005)
+    parser.add_argument("--alpha", type=float, default=0.2)
+    parser.add_argument("--lr-actor", type=float, default=3e-4)
+    parser.add_argument("--lr-critic", type=float, default=3e-4)
+    parser.add_argument("--lr-alpha", type=float, default=3e-4)
+    args = parser.parse_args()
+
+    run_training(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/pixyzrl/models/__init__.py
+++ b/pixyzrl/models/__init__.py
@@ -1,11 +1,11 @@
 from .base_model import RLModel
+from .off_policy.sac import SAC
 from .on_policy.a2c import A2C
-from .on_policy.actor_critic import ActorCritic
 from .on_policy.ppo import PPO
 
 __all__ = [
     "A2C",
     "PPO",
-    "ActorCritic",
+    "SAC",
     "RLModel",
 ]

--- a/pixyzrl/models/off_policy/__init__.py
+++ b/pixyzrl/models/off_policy/__init__.py
@@ -1,0 +1,3 @@
+from .sac import SAC
+
+__all__ = ["SAC"]

--- a/pixyzrl/models/off_policy/sac.py
+++ b/pixyzrl/models/off_policy/sac.py
@@ -1,0 +1,246 @@
+"""Soft Actor-Critic (SAC) agent using Pixyz distributions."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import torch
+from pixyz import distributions as dists
+from torch.optim import Adam
+from torch.utils.data import DataLoader
+
+from pixyzrl.memory import BaseBuffer
+from pixyzrl.models.base_model import RLModel
+
+
+class SAC(RLModel):
+    """Soft Actor-Critic (SAC) for continuous control."""
+
+    def __init__(
+        self,
+        actor: dists.Distribution,
+        critic1: dists.Distribution,
+        critic2: dists.Distribution,
+        lr_actor: float = 3e-4,
+        lr_critic: float = 3e-4,
+        lr_alpha: float = 3e-4,
+        gamma: float = 0.99,
+        tau: float = 0.005,
+        alpha: float = 0.2,
+        auto_entropy_tuning: bool = True,
+        target_entropy: float | None = None,
+        action_var: str = "a",
+        obs_var: str | None = None,
+        next_obs_var: str = "o_next",
+        reward_var: str = "r",
+        done_var: str = "d",
+        device: str = "cpu",
+    ) -> None:
+        self._is_on_policy = False
+        self._action_var = action_var
+
+        self.actor = actor.to(device)
+        self.critic1 = critic1.to(device)
+        self.critic2 = critic2.to(device)
+        self.target_critic1 = deepcopy(critic1).to(device)
+        self.target_critic2 = deepcopy(critic2).to(device)
+
+        self.obs_var = obs_var or actor.cond_var[0]
+        self.next_obs_var = next_obs_var
+        self.reward_var = reward_var
+        self.done_var = done_var
+
+        self.gamma = gamma
+        self.tau = tau
+        self.lr_alpha = lr_alpha
+        self.auto_entropy_tuning = auto_entropy_tuning
+        self.target_entropy = target_entropy
+        self.device = device
+
+        if self.target_entropy is None:
+            self.target_entropy = -1.0
+
+        dummy_loss = -self.actor.log_prob().mean()
+
+        super().__init__(
+            dummy_loss,
+            distributions=[
+                self.actor,
+                self.critic1,
+                self.critic2,
+                self.target_critic1,
+                self.target_critic2,
+            ],
+            optimizer=Adam,
+            optimizer_params={},
+        )
+
+        self.actor_optimizer = Adam(self.actor.parameters(), lr=lr_actor)
+        self.critic_optimizer = Adam(
+            [
+                {"params": self.critic1.parameters(), "lr": lr_critic},
+                {"params": self.critic2.parameters(), "lr": lr_critic},
+            ]
+        )
+
+        if self.auto_entropy_tuning:
+            self.log_alpha = torch.nn.Parameter(
+                torch.log(torch.tensor([float(alpha)], device=device))
+            )
+            self.alpha_optimizer = Adam([self.log_alpha], lr=self.lr_alpha)
+        else:
+            self.log_alpha = torch.log(torch.tensor([float(alpha)], device=device))
+            self.alpha_optimizer = None
+
+        self.transfer_state_dict()
+
+    @property
+    def alpha(self) -> torch.Tensor:
+        return self.log_alpha.exp()
+
+    @torch.no_grad()
+    def select_action(self, state: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        actor_input = {self.obs_var: state[self.obs_var].to(self.device)}
+        return self.actor.sample(actor_input)
+
+    def _critic_value(
+        self,
+        critic: dists.Distribution,
+        obs: torch.Tensor,
+        action: torch.Tensor,
+    ) -> torch.Tensor:
+        q = critic.sample({critic.cond_var[0]: obs, critic.cond_var[1]: action})[
+            critic.var[0]
+        ]
+        return q
+
+    def train_step(
+        self,
+        memory: BaseBuffer,
+        batch_size: int = 256,
+        num_epochs: int = 1,
+    ) -> float:
+        dataloader = DataLoader(memory, batch_size=batch_size, shuffle=True)
+        total_loss = 0.0
+
+        for _ in range(num_epochs):
+            for batch in dataloader:
+                obs = batch[self.obs_var].to(self.device)
+                actions = batch[self.action_var].to(self.device)
+                rewards = batch[self.reward_var].to(self.device)
+                dones = batch[self.done_var].to(self.device).float()
+                next_obs = batch[self.next_obs_var].to(self.device)
+
+                with torch.no_grad():
+                    next_action = self.actor.sample({self.obs_var: next_obs})[
+                        self.action_var
+                    ]
+                    next_log_prob = (
+                        self.actor.log_prob()
+                        .eval({self.obs_var: next_obs, self.action_var: next_action})
+                        .sum(dim=-1, keepdim=True)
+                    )
+                    target_q1 = self._critic_value(
+                        self.target_critic1,
+                        next_obs,
+                        next_action,
+                    )
+                    target_q2 = self._critic_value(
+                        self.target_critic2,
+                        next_obs,
+                        next_action,
+                    )
+                    target_q = torch.min(target_q1, target_q2) - self.alpha * next_log_prob
+                    target = rewards + (1.0 - dones) * self.gamma * target_q
+
+                current_q1 = self._critic_value(self.critic1, obs, actions)
+                current_q2 = self._critic_value(self.critic2, obs, actions)
+                critic_loss = torch.nn.functional.mse_loss(
+                    current_q1,
+                    target,
+                ) + torch.nn.functional.mse_loss(current_q2, target)
+
+                self.critic_optimizer.zero_grad()
+                critic_loss.backward()
+                self.critic_optimizer.step()
+
+                sampled_action = self.actor.sample({self.obs_var: obs})[self.action_var]
+                log_prob = (
+                    self.actor.log_prob()
+                    .eval({self.obs_var: obs, self.action_var: sampled_action})
+                    .sum(dim=-1, keepdim=True)
+                )
+                q1_pi = self._critic_value(self.critic1, obs, sampled_action)
+                q2_pi = self._critic_value(self.critic2, obs, sampled_action)
+                min_q_pi = torch.min(q1_pi, q2_pi)
+                actor_loss = (self.alpha.detach() * log_prob - min_q_pi).mean()
+
+                self.actor_optimizer.zero_grad()
+                actor_loss.backward()
+                self.actor_optimizer.step()
+
+                alpha_loss = torch.tensor(0.0, device=self.device)
+                if self.auto_entropy_tuning and self.alpha_optimizer is not None:
+                    alpha_loss = -(
+                        self.log_alpha * (log_prob + self.target_entropy).detach()
+                    ).mean()
+                    self.alpha_optimizer.zero_grad()
+                    alpha_loss.backward()
+                    self.alpha_optimizer.step()
+
+                self._soft_update_targets()
+                total_loss += float((critic_loss + actor_loss + alpha_loss).detach())
+
+        return total_loss / max(1, len(dataloader) * num_epochs)
+
+    @torch.no_grad()
+    def _soft_update_targets(self) -> None:
+        for target_param, param in zip(
+            self.target_critic1.parameters(), self.critic1.parameters(), strict=False
+        ):
+            target_param.data.mul_(1.0 - self.tau).add_(self.tau * param.data)
+
+        for target_param, param in zip(
+            self.target_critic2.parameters(), self.critic2.parameters(), strict=False
+        ):
+            target_param.data.mul_(1.0 - self.tau).add_(self.tau * param.data)
+
+    @torch.no_grad()
+    def transfer_state_dict(self) -> None:
+        self.target_critic1.load_state_dict(self.critic1.state_dict())
+        self.target_critic2.load_state_dict(self.critic2.state_dict())
+
+    def save(self, path: str) -> None:
+        torch.save(
+            {
+                "actor": self.actor.state_dict(),
+                "critic1": self.critic1.state_dict(),
+                "critic2": self.critic2.state_dict(),
+                "target_critic1": self.target_critic1.state_dict(),
+                "target_critic2": self.target_critic2.state_dict(),
+                "actor_optimizer": self.actor_optimizer.state_dict(),
+                "critic_optimizer": self.critic_optimizer.state_dict(),
+                "log_alpha": self.log_alpha.detach().cpu(),
+                "alpha_optimizer": self.alpha_optimizer.state_dict()
+                if self.alpha_optimizer is not None
+                else None,
+            },
+            path,
+        )
+
+    def load(self, path: str) -> None:
+        checkpoint = torch.load(path, map_location=self.device)
+        self.actor.load_state_dict(checkpoint["actor"])
+        self.critic1.load_state_dict(checkpoint["critic1"])
+        self.critic2.load_state_dict(checkpoint["critic2"])
+        self.target_critic1.load_state_dict(checkpoint["target_critic1"])
+        self.target_critic2.load_state_dict(checkpoint["target_critic2"])
+        self.actor_optimizer.load_state_dict(checkpoint["actor_optimizer"])
+        self.critic_optimizer.load_state_dict(checkpoint["critic_optimizer"])
+
+        if self.auto_entropy_tuning:
+            self.log_alpha = torch.nn.Parameter(checkpoint["log_alpha"].to(self.device))
+            self.alpha_optimizer = Adam([self.log_alpha], lr=self.lr_alpha)
+            if checkpoint["alpha_optimizer"] is not None:
+                self.alpha_optimizer.load_state_dict(checkpoint["alpha_optimizer"])
+        else:
+            self.log_alpha = checkpoint["log_alpha"].to(self.device)

--- a/pixyzrl/models/on_policy/__init__.py
+++ b/pixyzrl/models/on_policy/__init__.py
@@ -1,4 +1,4 @@
 from .a2c import A2C
-from .actor_critic import ActorCritic
+from .ppo import PPO
 
-__all__ = ["A2C", "ActorCritic"]
+__all__ = ["A2C", "PPO"]

--- a/tests/test_sac.py
+++ b/tests/test_sac.py
@@ -1,0 +1,58 @@
+import torch
+from pixyz.distributions import Deterministic, Normal
+
+from pixyzrl.memory import RolloutBuffer
+from pixyzrl.models import SAC
+
+
+class DummyActor(Normal):
+    def __init__(self) -> None:
+        super().__init__(var=["a"], cond_var=["o"], name="pi")
+        self.net = torch.nn.Linear(4, 2)
+
+    def forward(self, o: torch.Tensor) -> dict[str, torch.Tensor]:
+        loc = self.net(o)
+        scale = torch.ones_like(loc) * 0.5
+        return {"loc": loc, "scale": scale}
+
+
+class DummyCritic(Deterministic):
+    def __init__(self, name: str) -> None:
+        super().__init__(var=["q"], cond_var=["o", "a"], name=name)
+        self.net = torch.nn.Linear(6, 1)
+
+    def forward(self, o: torch.Tensor, a: torch.Tensor) -> dict[str, torch.Tensor]:
+        return {"q": self.net(torch.cat([o, a], dim=-1))}
+
+
+def test_sac_train_step_runs() -> None:
+    actor = DummyActor()
+    critic1 = DummyCritic("q1")
+    critic2 = DummyCritic("q2")
+    sac = SAC(actor, critic1, critic2)
+
+    buffer = RolloutBuffer(
+        buffer_size=8,
+        env_dict={
+            "obs": {"shape": (4,), "map": "o"},
+            "next_obs": {"shape": (4,), "map": "o_next"},
+            "action": {"shape": (2,), "map": "a"},
+            "reward": {"shape": (1,), "map": "r"},
+            "done": {"shape": (1,), "map": "d"},
+            "value": {"shape": (1,), "map": "v"},
+        },
+        n_envs=1,
+    )
+
+    for _ in range(8):
+        buffer.add(
+            obs=torch.randn(4),
+            next_obs=torch.randn(4),
+            action=torch.randn(2),
+            reward=torch.randn(1),
+            done=torch.zeros(1),
+            value=torch.zeros(1),
+        )
+
+    loss = sac.train_step(buffer, batch_size=4, num_epochs=1)
+    assert isinstance(loss, float)


### PR DESCRIPTION
### Motivation
- Provide an off-policy continuous-control algorithm implementation (SAC) to the framework so users can train stochastic continuous policies with entropy regularization and twin critics.
- Expose the new model from package entry points and fix a stale on-policy export that caused import errors during testing.

### Description
- Add a new SAC implementation at `pixyzrl/models/off_policy/sac.py` implementing twin critics, target critics, soft target updates (`tau`), entropy regularization with optional automatic temperature tuning (`alpha`), `train_step`, and `save`/`load` support.
- Export `SAC` from `pixyzrl/models/off_policy/__init__.py` and from the top-level `pixyzrl/models/__init__.py`, and update `pixyzrl/models/on_policy/__init__.py` to export the existing `A2C` and `PPO` modules to fix import failures.
- Fix alpha parameter handling by making `log_alpha` a `torch.nn.Parameter` and centralize `lr_alpha` usage so the alpha optimizer is created/loaded correctly during `__init__` and `load`.
- Add a unit test `tests/test_sac.py` that uses dummy Pixyz `Normal`/`Deterministic` distributions and a `RolloutBuffer` to verify that `sac.train_step(...)` runs and returns a float loss, and update `README.md` to note SAC support.

### Testing
- Ran `PYTHONPATH=. pytest -q` after fixes and the SAC unit test passed with `1 passed`.
- Earlier test runs recorded an import error and a non-leaf tensor optimizer error which were fixed by updating `models` exports and converting `log_alpha` to a `nn.Parameter`, respectively, and subsequent tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afa0a1b2e88323ac2a0e4e4eab944a)