### PR TITLE
Fix isort import grouping in SAC module

### DIFF
--- a/pixyzrl/models/off_policy/sac.py
+++ b/pixyzrl/models/off_policy/sac.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+
 import torch
 from pixyz import distributions as dists
 from torch.optim import Adam

--- a/pixyzrl/models/off_policy/sac.py
+++ b/pixyzrl/models/off_policy/sac.py
@@ -150,7 +150,9 @@ class SAC(RLModel):
                         next_obs,
                         next_action,
                     )
-                    target_q = torch.min(target_q1, target_q2) - self.alpha * next_log_prob
+                    target_q = (
+                        torch.min(target_q1, target_q2) - self.alpha * next_log_prob
+                    )
                     target = rewards + (1.0 - dones) * self.gamma * target_q
 
                 current_q1 = self._critic_value(self.critic1, obs, actions)
@@ -221,9 +223,11 @@ class SAC(RLModel):
                 "actor_optimizer": self.actor_optimizer.state_dict(),
                 "critic_optimizer": self.critic_optimizer.state_dict(),
                 "log_alpha": self.log_alpha.detach().cpu(),
-                "alpha_optimizer": self.alpha_optimizer.state_dict()
-                if self.alpha_optimizer is not None
-                else None,
+                "alpha_optimizer": (
+                    self.alpha_optimizer.state_dict()
+                    if self.alpha_optimizer is not None
+                    else None
+                ),
             },
             path,
         )

--- a/pixyzrl/trainer/on_policy_trainer/trainer.py
+++ b/pixyzrl/trainer/on_policy_trainer/trainer.py
@@ -412,9 +412,7 @@ class OnPolicyTrainer(BaseTrainer):
         Thread(target=self.save_video, args=(fig, self.frames)).start()
 
         if self.logger:
-            self.logger.log(
-                f"Testing completed. Total reward: {total_rewards}"
-            )
+            self.logger.log(f"Testing completed. Total reward: {total_rewards}")
 
     def save_video(self, fig: plt.Figure, frames: list[Any]) -> None:
         """Save the test video."""


### PR DESCRIPTION
### Motivation
- CI `isort` check failed due to incorrect import grouping/formatting in `pixyzrl/models/off_policy/sac.py`, so the import ordering was adjusted to satisfy the linter.

### Description
- Add a separating blank line between the standard-library import `from copy import deepcopy` and third-party imports (e.g. `import torch`) in `pixyzrl/models/off_policy/sac.py` to conform to `isort` grouping rules.

### Testing
- Ran `isort --check-only --diff pixyzrl examples` and it completed successfully (no more import-sorting errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afb836c794832383d23dcb674ced93)