### PR TITLE
Add root .flake8 config to enforce project lint settings

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 160
+extend-ignore = E203

--- a/pixyzrl/environments/env.py
+++ b/pixyzrl/environments/env.py
@@ -5,9 +5,9 @@ from abc import ABC, abstractmethod
 from typing import Any, SupportsFloat
 
 import gymnasium as gym
+import numpy as np
 import pybullet as p
 import pybullet_data as pd
-import numpy as np
 import torch
 from gymnasium import spaces
 from gymnasium.spaces import Discrete, MultiDiscrete, Space


### PR DESCRIPTION
### Motivation
- Some `flake8` installations do not read `[tool.flake8]` from `pyproject.toml`, causing CI/lint runs to use default rules and surface `E501`/`E203` errors; adding a root `.flake8` ensures the intended settings are applied.

### Description
- Add a repository root `.flake8` file with `max-line-length = 160` and `extend-ignore = E203` to match the existing `pyproject.toml` lint policy.

### Testing
- Attempted to run `flake8 pixyzrl`, but `flake8` is not installed in the execution environment so the lint run could not be performed; attempting `python -m pip install flake8` failed due to network/proxy restrictions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afbfb0b9e883238be4b575598ed079)