### PR TITLE
Add .flake8 and apply minor formatting fixes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 160
+extend-ignore = E203

--- a/pixyzrl/environments/env.py
+++ b/pixyzrl/environments/env.py
@@ -5,9 +5,9 @@ from abc import ABC, abstractmethod
 from typing import Any, SupportsFloat
 
 import gymnasium as gym
+import numpy as np
 import pybullet as p
 import pybullet_data as pd
-import numpy as np
 import torch
 from gymnasium import spaces
 from gymnasium.spaces import Discrete, MultiDiscrete, Space

--- a/pixyzrl/models/off_policy/sac.py
+++ b/pixyzrl/models/off_policy/sac.py
@@ -150,7 +150,9 @@ class SAC(RLModel):
                         next_obs,
                         next_action,
                     )
-                    target_q = torch.min(target_q1, target_q2) - self.alpha * next_log_prob
+                    target_q = (
+                        torch.min(target_q1, target_q2) - self.alpha * next_log_prob
+                    )
                     target = rewards + (1.0 - dones) * self.gamma * target_q
 
                 current_q1 = self._critic_value(self.critic1, obs, actions)
@@ -221,9 +223,11 @@ class SAC(RLModel):
                 "actor_optimizer": self.actor_optimizer.state_dict(),
                 "critic_optimizer": self.critic_optimizer.state_dict(),
                 "log_alpha": self.log_alpha.detach().cpu(),
-                "alpha_optimizer": self.alpha_optimizer.state_dict()
-                if self.alpha_optimizer is not None
-                else None,
+                "alpha_optimizer": (
+                    self.alpha_optimizer.state_dict()
+                    if self.alpha_optimizer is not None
+                    else None
+                ),
             },
             path,
         )

--- a/pixyzrl/trainer/on_policy_trainer/trainer.py
+++ b/pixyzrl/trainer/on_policy_trainer/trainer.py
@@ -412,9 +412,7 @@ class OnPolicyTrainer(BaseTrainer):
         Thread(target=self.save_video, args=(fig, self.frames)).start()
 
         if self.logger:
-            self.logger.log(
-                f"Testing completed. Total reward: {total_rewards}"
-            )
+            self.logger.log(f"Testing completed. Total reward: {total_rewards}")
 
     def save_video(self, fig: plt.Figure, frames: list[Any]) -> None:
         """Save the test video."""


### PR DESCRIPTION
### Motivation
- Add a project flake8 configuration and adjust minor code formatting to keep code style consistent and avoid line-length issues.

### Description
- Add `.flake8` with `max-line-length = 160` and `extend-ignore = E203`.
- Reorder/import `numpy as np` in `pixyzrl/environments/env.py` and apply small formatting/parenthesization changes in `pixyzrl/models/off_policy/sac.py` and `pixyzrl/trainer/on_policy_trainer/trainer.py` to improve line wrapping and readability.

### Testing
- Ran the project's linting with `flake8` and executed the automated test suite; both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afbfb0b9e883238be4b575598ed079)