### PR TITLE
Fix doctest examples for updated Env, Loss, and RolloutBuffer APIs

### DIFF
--- a/pixyzrl/environments/env.py
+++ b/pixyzrl/environments/env.py
@@ -181,8 +181,9 @@ class Env(BaseEnv):
             >>> import torch
             >>> env = Env("CartPole-v1")
             >>> obs, info = env.reset()
-            >>> action = torch.Tensor(1)
-            >>> obs, reward, terminated, truncated, info = env.step({"a": torch.argmax(action).item()})
+            >>> action = torch.zeros((1, 2))
+            >>> obs, reward, terminated, truncated, info = env.step({"a": action})
+            >>> env.close()
         """
         if self._env.action_space.shape is None:
             msg = "Unsupported action space type"

--- a/pixyzrl/losses/losses.py
+++ b/pixyzrl/losses/losses.py
@@ -16,7 +16,7 @@ class PPOClipLoss(Loss):
     --------
     >>> import torch
     >>> from pixyz.distributions import Normal
-    >>> from pixyz.losses import PPOClipLoss
+    >>> from pixyzrl.losses import PPOClipLoss
     ...
     >>> class P(Normal):
     ...
@@ -27,11 +27,13 @@ class PPOClipLoss(Loss):
     ...         return {"loc": x, "scale": torch.nn.functional.softplus(x)}
     ...
     >>> p = P()
-    >>> ppo_clip_loss = PPOClipLoss(p, 0.2)
+    >>> q = P()
+    >>> ppo_clip_loss = PPOClipLoss(p, q, 0.2)
     >>> x = torch.zeros(1, 128)
     >>> z = torch.zeros(1, 128)
-    >>> ppo_clip_loss.eval({"z": z, "x": x})
-    tensor(0.)  # Expected output
+    >>> A = torch.ones(1, 1)
+    >>> ppo_clip_loss.eval({"z": z, "x": x, "A": A}).shape
+    torch.Size([1, 1])
     """
 
     def __init__(
@@ -204,7 +206,7 @@ class MSELoss(Loss):
     >>> y = torch.rand(1, 128)
     >>>
     >>> mse_loss.eval({"x": x, "y": y}).shape
-    torch.Size([])
+    torch.Size([128])
 
     """
 
@@ -238,7 +240,7 @@ class ValueClipLoss(Loss):
     --------
     >>> import torch
     >>> from pixyz.distributions import Normal
-    >>> from pixyz.losses import ValueClipLoss
+    >>> from pixyzrl.losses import ValueClipLoss
     ...
     >>> class P(Normal):
     ...
@@ -249,11 +251,12 @@ class ValueClipLoss(Loss):
     ...         return {"loc": x, "scale": torch.nn.functional.softplus(x)}
     ...
     >>> p = P()
-    >>> value_clip_loss = ValueClipLoss(p, 0.2)
+    >>> value_clip_loss = ValueClipLoss(p, "v_target", 0.2)
     >>> x = torch.zeros(1, 128)
     >>> z = torch.zeros(1, 128)
-    >>> value_clip_loss.eval({"z": z, "x": x})
-    tensor(0.)  # Expected output
+    >>> v_target = torch.zeros(1, 128)
+    >>> value_clip_loss.eval({"x": x, "z": z, "v_target": v_target}).shape
+    torch.Size([1, 128])
     """
 
     def __init__(self, p: Distribution, vtarget_var: str, clip: float) -> None:

--- a/pixyzrl/memory/memory.py
+++ b/pixyzrl/memory/memory.py
@@ -104,7 +104,8 @@ class BaseBuffer(Dataset):
             >>> buffer.add(obs=np.random.rand(4), action=np.random.rand(1), reward=np.random.rand(1), done=np.random.rand(1))
             >>> buffer.add(obs=np.random.rand(4), action=np.random.rand(1), reward=np.random.rand(1), done=np.random.rand(1))
             >>>
-            >>> buffer[0]
+            >>> sorted(buffer[0].keys())
+            ['a', 'd', 'o', 'r']
         """
 
         mini_batch = {}
@@ -494,9 +495,8 @@ class RolloutBuffer(BaseBuffer):
             >>> buffer.add(obs=np.zeros(4), action=np.zeros(1), reward=np.ones(1), done=np.zeros(1), value=np.zeros(1))
             >>> buffer.add(obs=np.zeros(4), action=np.zeros(1), reward=np.ones(1), done=np.zeros(1), value=np.zeros(1))
             >>>
-            >>> last_value = torch.zeros(1)
-            >>> return_advantage = buffer.compute_returns_and_advantages_grpo()
-            >>> "returns" in return_advantage and "advantages" in return_advantage
+            >>> return_advantage = buffer.compute_advantages_grpo()
+            >>> "advantages" in return_advantage
             True
         """
         for key, value in self.buffer.items():


### PR DESCRIPTION
### Motivation
- Doctest examples were out of sync with recent API changes to `Env`, several loss classes, and the rollout/memory buffer, causing CI doctest failures. 

### Description
- Updated `Env.step` example in `pixyzrl/environments/env.py` to use a vector-compatible action input and close the environment in the example. 
- Fixed loss examples in `pixyzrl/losses/losses.py` to import the project-local module (`pixyzrl.losses`), adjusted `PPOClipLoss` usage to accept both `p` and `q` distributions and include the `A` advantage input, and adjusted `ValueClipLoss` usage to include the `z` sample and named target variable. 
- Aligned `MSELoss` doctest expected output shape with the current `reduction="none"` behavior. 
- Stabilized `BaseBuffer.__getitem__` doctest in `pixyzrl/memory/memory.py` to check the returned keys instead of printing nondeterministic tensor values and updated the GRPO example to call `compute_advantages_grpo()` and assert the returned `advantages` key. 

### Testing
- Ran doctests with `pytest --doctest-modules -q pixyzrl`, and all doctest modules passed. 
- Ran `PYTHONPATH=. pytest -q tests/test_sac.py`, and the test passed. 
- Running `pytest -q` without `PYTHONPATH` in this checkout environment fails during collection due to import path setup, which is unrelated to the doctest fixes above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afc891d0748323aa8338b24ecb4dd8)