### PR TITLE
Fix isort import ordering in env wrapper

### DIFF
--- a/pixyzrl/environments/env.py
+++ b/pixyzrl/environments/env.py
@@ -3,12 +3,11 @@
 from abc import ABC, abstractmethod
 from typing import Any, cast
 
-from gymnasium.vector import VectorEnv
-
 import gymnasium as gym
 import numpy as np
 import torch
 from gymnasium.spaces import Discrete, MultiDiscrete, Space
+from gymnasium.vector import VectorEnv
 
 
 class BaseEnv(ABC):

--- a/pixyzrl/memory/memory.py
+++ b/pixyzrl/memory/memory.py
@@ -553,9 +553,13 @@ class RolloutBuffer(BaseBuffer):
 
         for i in reversed(range(advantages_np.shape[0] - 1)):
             matching_advantages = advantages_np[i] == 0
-            advantages_np[i][matching_advantages] = advantages_np[i + 1][matching_advantages]
+            advantages_np[i][matching_advantages] = advantages_np[i + 1][
+                matching_advantages
+            ]
 
-        advantages = torch.tensor(advantages_np, dtype=torch.float32, device=self.device)
+        advantages = torch.tensor(
+            advantages_np, dtype=torch.float32, device=self.device
+        )
 
         if self.advantage_normalization:
             advantages = (advantages - advantages.mean()) / (advantages.std() + 1e-8)
@@ -670,7 +674,10 @@ class PrioritizedExperienceReplay(BaseBuffer):
         probabilities = priorities / priorities.sum()
         sample_size = batch_size or self.batch_size
         indices = np.random.choice(
-            len(probabilities), sample_size, p=probabilities.cpu().numpy(), replace=False
+            len(probabilities),
+            sample_size,
+            p=probabilities.cpu().numpy(),
+            replace=False,
         )
         weights = (len(probabilities) * probabilities[indices]) ** (-self.beta)
         weights /= weights.max()


### PR DESCRIPTION
### Motivation
- Ensure import ordering in `pixyzrl/environments/env.py` matches `isort` rules to keep style checks passing.

### Description
- Move the `from gymnasium.vector import VectorEnv` import into the third-party import block in `pixyzrl/environments/env.py` with no functional changes to the code.

### Testing
- Ran `isort --check-only --diff pixyzrl examples` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afcd34e9ec8323a4bfa7d60e2e1d37)