### PR TITLE
fix: resolve isort failures in env and dreamer example

### DIFF
--- a/examples/dreamer_carracing/main.py
+++ b/examples/dreamer_carracing/main.py
@@ -1,25 +1,24 @@
 from __future__ import annotations
-from datetime import datetime
-import torch
-from torch import optim
-from tensorboardX import SummaryWriter
-from tqdm import tqdm
-import gc
 
-from pixyzrl.environments import Env
-from pixyz.losses import LogProb, Parameter
-from pixyz.models import Model
+import gc
+from datetime import datetime
+
+import torch
 from memory import ExperienceReplay
 from models import Actor, Critic, RecurrentStateSpaceModel
+from pixyz.losses import LogProb, Parameter
+from pixyz.models import Model
+from tensorboardX import SummaryWriter
+from torch import optim
+from tqdm import tqdm
 from utils import (
     FreezeParameters,
     imagine_ahead,
     lambda_return,
 )
-from pixyzrl.environments.env import ResizeObservation, BitDepthQuantize, ScaleAction
 
-
-
+from pixyzrl.environments import Env
+from pixyzrl.environments.env import BitDepthQuantize, ResizeObservation, ScaleAction
 
 # ============================================
 # Config

--- a/pixyzrl/environments/env.py
+++ b/pixyzrl/environments/env.py
@@ -1,17 +1,15 @@
 """Single Gym environment wrapper."""
 
+import math
+import time
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Callable, List
 
+import cv2
 import gymnasium as gym
 import numpy as np
 import torch
-from gymnasium.spaces import Discrete, MultiDiscrete, Space
-from typing import Callable, List
-import cv2
-from gymnasium.spaces import Box
-import math
-import time
+from gymnasium.spaces import Box, Discrete, MultiDiscrete, Space
 
 
 class BaseEnv(ABC):


### PR DESCRIPTION
### Motivation
- Fix import-sorting/style issues that caused `isort` failures in the repository and blocked CI checks.
- Keep import blocks consistent (stdlib, third-party, local) to satisfy tooling and reduce noisy diffs.

### Description
- Reordered and grouped imports in `pixyzrl/environments/env.py` to follow `isort` conventions and consolidated `gymnasium.spaces` imports into a single line.
- Reordered imports in `examples/dreamer_carracing/main.py`, moved related imports together, and removed an extra blank line between import blocks.
- Ensured the files end with a newline and adjusted import ordering without changing runtime logic.

### Testing
- Ran `isort --check-only --diff pixyzrl examples` and the check passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b01af2fd54832397e65ac869c52511)