### PR TITLE
Fix import ordering in pixyzrl/environments/env.py

### DIFF
--- a/pixyzrl/environments/env.py
+++ b/pixyzrl/environments/env.py
@@ -7,13 +7,9 @@ from typing import Any, Callable, List
 
 import cv2
 import gymnasium as gym
-import math
 import numpy as np
 import torch
-import time
-from typing import Callable, List
-from gymnasium.spaces import Box
-from gymnasium.spaces import Discrete, MultiDiscrete, Space
+from gymnasium.spaces import Box, Discrete, MultiDiscrete, Space
 
 
 class BaseEnv(ABC):


### PR DESCRIPTION
### Motivation
- Address an `isort` failure by removing duplicated imports and correcting import grouping in `pixyzrl/environments/env.py`.

### Description
- Removed duplicate `math`, `time`, and repeated `Callable, List` imports and consolidated `gymnasium.spaces` imports into a single line (`from gymnasium.spaces import Box, Discrete, MultiDiscrete, Space`) to satisfy import-sorting rules.

### Testing
- Ran `isort --check-only --diff pixyzrl examples`, which succeeded (no diffs reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b01eb73ad88323b766239183c1fd4b)