### PR TITLE
tests: add conftest to ensure repo root is on sys.path

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
### Motivation

- Ensure test runs can import project packages by adding the repository root to `sys.path` during test collection.

### Description

- Add `tests/conftest.py` which computes `ROOT` via `Path(__file__).resolve().parents[1]` and inserts it into `sys.path` with `sys.path.insert(0, str(ROOT))` if not already present, and include `from __future__ import annotations`.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b03096ab748323b7f8e561e96dfcdd)